### PR TITLE
Use official blubberoid service that supports blubber 4 syntax

### DIFF
--- a/.bash_aliases
+++ b/.bash_aliases
@@ -10,7 +10,7 @@ ffmpegdownload() {
 }
 
 blubber() {
-    curl -s --data-binary "@$1" "https://tools.wmflabs.org/blubber/$2"
+    curl -s -H "Content-Type: application/yaml" --data-binary "@$1" "https://blubberoid.wikimedia.org/v1/$2"
 }
 
 pdfmerge() {


### PR DESCRIPTION
Termbox recently upgraded to blubber v4: https://gerrit.wikimedia.org/r/c/wikibase/termbox/+/525466
tools.wmflabs.org/blubber/ is an outdated (, unofficial?) version of blubberoid, that does not yet support the new syntax.